### PR TITLE
Add DIRECT_URL parameter 

### DIFF
--- a/charts/blobscan-api/Chart.yaml
+++ b/charts/blobscan-api/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/Blobscan/blobscan/main/.github/assets/lo
 sources:
   - https://github.com/blobscan/blobscan/
 type: application
-version: 0.3.1
+version: 0.3.2
 maintainers:
   - name: PabloCastellano
     email: pablo@anche.no

--- a/charts/blobscan-api/README.md
+++ b/charts/blobscan-api/README.md
@@ -1,7 +1,7 @@
 
 # blobscan-api
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Blobscan API
 

--- a/charts/blobscan-api/README.md
+++ b/charts/blobscan-api/README.md
@@ -19,6 +19,27 @@ Blobscan API
 | annotations | object | `{}` | Annotations for the Deployment |
 | args | list | `[]` | Command arguments |
 | config | object | See `values.yaml` | Config file https://github.com/Blobscan/blobscan/blob/main/.env.example |
+| config.BEE_ENDPOINT | string | `"http://localhost:1633"` | Swarm Bee node endpoint for decentralized storage |
+| config.BLOBSCAN_API_BASE_URL | string | `"http://blobscan-api:3001"` | Base URL for the Blobscan API service |
+| config.BLOBSCAN_API_PORT | int | `3001` | Port on which the Blobscan API service listens |
+| config.CHAIN_ID | string | `"1"` | Ethereum network chain ID (1 for mainnet) |
+| config.DATABASE_URL | string | `"postgresql://postgres:postgres@blobscan-blobscandb:5432/blobscan?ssl=false"` | PostgreSQL connection string for the main database connection |
+| config.DIRECT_URL | string | `"postgresql://postgres:postgres@blobscan-blobscandb:5432/blobscan?ssl=false"` | Direct PostgreSQL connection string, used for Prisma direct database access |
+| config.GOOGLE_SERVICE_KEY | string | `""` | Google Cloud service account key for authentication (JSON format) |
+| config.GOOGLE_STORAGE_BUCKET_NAME | string | `""` | Google Cloud Storage bucket name for blob data storage |
+| config.GOOGLE_STORAGE_ENABLED | string | `"false"` | Enable Google Cloud Storage for blob data |
+| config.GOOGLE_STORAGE_PROJECT_ID | string | `""` | Google Cloud project ID for blob data storage |
+| config.METRICS_ENABLED | string | `"true"` | Enable metrics collection and reporting |
+| config.NETWORK_NAME | string | `"mainnet"` | Ethereum network name (mainnet, holesky, sepolia, gnosis) |
+| config.OTEL_EXPORTER_OTLP_ENDPOINT | string | `"http://localhost:4318"` | Endpoint URL for OpenTelemetry data export |
+| config.OTEL_EXPORTER_OTLP_PROTOCOL | string | `"http/protobuf"` | Protocol used for OpenTelemetry data export |
+| config.OTLP_AUTH_PASSWORD | string | `""` | Password for OpenTelemetry authentication |
+| config.OTLP_AUTH_USERNAME | string | `""` | Username for OpenTelemetry authentication |
+| config.POSTGRES_STORAGE_ENABLED | string | `"true"` | Enable PostgreSQL storage for blob data |
+| config.REDIS_URI | string | `"redis://blobscan-redis-master:6379/1"` | Redis connection URI for caching and queue management |
+| config.SECRET_KEY | string | `"supersecret"` | Secret key used for session management and encryption |
+| config.SWARM_STORAGE_ENABLED | string | `"false"` | Enable Swarm decentralized storage for blob data |
+| config.TRACES_ENABLED | string | `"false"` | Enable distributed tracing |
 | containerSecurityContext | object | See `values.yaml` | The security context for containers |
 | customArgs | list | `["api"]` | Custom args for the blobscan-api container |
 | customCommand | list | `[]` | Command replacement for the blobscan-api container |

--- a/charts/blobscan-api/values.yaml
+++ b/charts/blobscan-api/values.yaml
@@ -28,29 +28,47 @@ args: []
 # @default -- See `values.yaml`
 # https://github.com/Blobscan/blobscan/blob/main/.env.example
 config:
+  # -- Ethereum network chain ID (1 for mainnet)
   CHAIN_ID: "1"
+  # -- PostgreSQL connection string for the main database connection
   DATABASE_URL: "postgresql://postgres:postgres@blobscan-blobscandb:5432/blobscan?ssl=false"
+  # -- Direct PostgreSQL connection string, used for Prisma direct database access
+  DIRECT_URL: "postgresql://postgres:postgres@blobscan-blobscandb:5432/blobscan?ssl=false"
+  # -- Redis connection URI for caching and queue management
   REDIS_URI: "redis://blobscan-redis-master:6379/1"
+  # -- Secret key used for session management and encryption
   SECRET_KEY: "supersecret"
+  # -- Ethereum network name (mainnet, holesky, sepolia, gnosis)
   NETWORK_NAME: "mainnet"
+  # -- Base URL for the Blobscan API service
   BLOBSCAN_API_BASE_URL: "http://blobscan-api:3001"
+  # -- Port on which the Blobscan API service listens
   BLOBSCAN_API_PORT: 3001
-  # Storages: General
+  # -- Enable PostgreSQL storage for blob data
   POSTGRES_STORAGE_ENABLED: "true"
+  # -- Enable Swarm decentralized storage for blob data
   SWARM_STORAGE_ENABLED: "false"
+  # -- Enable Google Cloud Storage for blob data
   GOOGLE_STORAGE_ENABLED: "false"
-  # Storages: Google Cloud specific
+  # -- Google Cloud Storage bucket name for blob data storage
   GOOGLE_STORAGE_BUCKET_NAME: ""
+  # -- Google Cloud project ID for blob data storage
   GOOGLE_STORAGE_PROJECT_ID: ""
+  # -- Google Cloud service account key for authentication (JSON format)
   GOOGLE_SERVICE_KEY: ""
-  # Storages: Swarm specific
+  # -- Swarm Bee node endpoint for decentralized storage
   BEE_ENDPOINT: "http://localhost:1633"
-  # Opentelemetry
+  # -- Username for OpenTelemetry authentication
   OTLP_AUTH_USERNAME: ""
+  # -- Password for OpenTelemetry authentication
   OTLP_AUTH_PASSWORD: ""
+  # -- Protocol used for OpenTelemetry data export
   OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  # -- Endpoint URL for OpenTelemetry data export
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318"
+  # -- Enable metrics collection and reporting
   METRICS_ENABLED: "true"
+  # -- Enable distributed tracing
   TRACES_ENABLED: "false"
 
 # -- Additional env variables

--- a/charts/blobscan-indexer/Chart.yaml
+++ b/charts/blobscan-indexer/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/Blobscan/blobscan/main/.github/assets/lo
 sources:
   - https://github.com/blobscan/blobscan-indexer
 type: application
-version: 0.2.10
+version: 0.2.11
 maintainers:
   - name: PabloCastellano
     email: pablo@anche.no

--- a/charts/blobscan-indexer/README.md
+++ b/charts/blobscan-indexer/README.md
@@ -1,7 +1,7 @@
 
 # blobscan-indexer
 
-![Version: 0.2.10](https://img.shields.io/badge/Version-0.2.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.11](https://img.shields.io/badge/Version-0.2.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Blobscan-indexer indexes blobs using Blobscan API.
 

--- a/charts/blobscan-indexer/README.md
+++ b/charts/blobscan-indexer/README.md
@@ -19,6 +19,13 @@ Blobscan-indexer indexes blobs using Blobscan API.
 | annotations | object | `{}` | Annotations for the Deployment |
 | args | list | `[]` | Command arguments |
 | config | object | See `values.yaml` | Config file https://github.com/Blobscan/blobscan/blob/next/.env.example |
+| config.BEACON_NODE_ENDPOINT | string | `"http://beacon-node:5052"` | Ethereum consensus layer (beacon chain) node endpoint URL |
+| config.BLOBSCAN_API_ENDPOINT | string | `"http://blobscan-api:3001"` | Blobscan API service endpoint URL |
+| config.EXECUTION_NODE_ENDPOINT | string | `"http://execution-node:8545"` | Ethereum execution layer node endpoint URL |
+| config.NETWORK_NAME | string | `"mainnet"` | Ethereum network name (mainnet, holesky, sepolia, gnosis) |
+| config.RUST_LOG | string | `"blob_indexer=INFO"` | Slot number when Dencun fork activated (uncomment and set for testnets) DENCUN_FORK_SLOT: "" -- Rust logging configuration for the blob indexer |
+| config.SECRET_KEY | string | `"supersecret"` | Secret key used for authentication and encryption |
+| config.SENTRY_DSN | string | `""` | Sentry DSN for error tracking and monitoring |
 | containerSecurityContext | object | See `values.yaml` | The security context for containers |
 | customArgs | list | `[]` | Custom args for the blobscan-indexer container |
 | customCommand | list | `[]` | Command replacement for the blobscan-indexer container |

--- a/charts/blobscan-indexer/templates/NOTES.txt
+++ b/charts/blobscan-indexer/templates/NOTES.txt
@@ -1,5 +1,5 @@
 1. Get the application URL by running these commands:
-{{- se if contains "NodePort" .Values.service.type }}
+{{- if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "blobscan-indexer.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT

--- a/charts/blobscan-indexer/values.yaml
+++ b/charts/blobscan-indexer/values.yaml
@@ -22,13 +22,21 @@ args: []
 # @default -- See `values.yaml`
 # https://github.com/Blobscan/blobscan/blob/next/.env.example
 config:
+  # -- Ethereum consensus layer (beacon chain) node endpoint URL
   BEACON_NODE_ENDPOINT: "http://beacon-node:5052"
+  # -- Blobscan API service endpoint URL
   BLOBSCAN_API_ENDPOINT: "http://blobscan-api:3001"
+  # -- Ethereum execution layer node endpoint URL
   EXECUTION_NODE_ENDPOINT: "http://execution-node:8545"
+  # -- Secret key used for authentication and encryption
   SECRET_KEY: "supersecret"
+  # -- Ethereum network name (mainnet, holesky, sepolia, gnosis)
   NETWORK_NAME: "mainnet"
-  # DENCUN_FORK_SLOT
+  # -- Slot number when Dencun fork activated (uncomment and set for testnets)
+  # DENCUN_FORK_SLOT: ""
+  # -- Rust logging configuration for the blob indexer
   RUST_LOG: "blob_indexer=INFO"
+  # -- Sentry DSN for error tracking and monitoring
   SENTRY_DSN: ""
 
 # -- Additional env variables

--- a/charts/blobscan-web/Chart.yaml
+++ b/charts/blobscan-web/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: blobscan-web
-version: 0.3.1
+version: 0.3.2
 description: Blobscan Web UI
 type: application
 keywords:

--- a/charts/blobscan-web/README.md
+++ b/charts/blobscan-web/README.md
@@ -1,7 +1,7 @@
 
 # blobscan-web
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Blobscan Web UI
 

--- a/charts/blobscan-web/README.md
+++ b/charts/blobscan-web/README.md
@@ -19,6 +19,24 @@ Blobscan Web UI
 | annotations | object | `{}` | Annotations for the Deployment |
 | args | list | `[]` | Command arguments |
 | config | object | See `values.yaml` | Config file https://github.com/Blobscan/blobscan/blob/main/.env.example |
+| config.BLOBSCAN_API_BASE_URL | string | `"http://blobscan-api:3001"` | Base URL for the Blobscan API service |
+| config.BLOBSCAN_API_PORT | int | `3001` | Port on which the Blobscan API service listens |
+| config.DATABASE_URL | string | `"postgresql://postgres:postgres@blobscan-blobscandb:5432/blobscan?ssl=false"` | PostgreSQL connection string for the main database connection |
+| config.DIRECT_URL | string | `"postgresql://postgres:postgres@blobscan-blobscandb:5432/blobscan?ssl=false"` | Direct PostgreSQL connection string, used for Prisma direct database access |
+| config.GOOGLE_SERVICE_KEY | string | `""` | Google Cloud service account key for authentication (JSON format) |
+| config.GOOGLE_STORAGE_BUCKET_NAME | string | `""` | Google Cloud Storage bucket name for blob data storage |
+| config.GOOGLE_STORAGE_ENABLED | string | `"false"` | Enable Google Cloud Storage for blob data |
+| config.GOOGLE_STORAGE_PROJECT_ID | string | `""` | Google Cloud project ID for blob data storage |
+| config.METRICS_ENABLED | string | `"true"` | Enable metrics collection and reporting |
+| config.NETWORK_NAME | string | `"mainnet"` | Ethereum network name (mainnet, holesky, sepolia, gnosis) |
+| config.OTEL_EXPORTER_OTLP_ENDPOINT | string | `"http://localhost:4318"` | Endpoint URL for OpenTelemetry data export |
+| config.OTEL_EXPORTER_OTLP_PROTOCOL | string | `"http/protobuf"` | Protocol used for OpenTelemetry data export |
+| config.OTLP_AUTH_PASSWORD | string | `""` | Password for OpenTelemetry authentication |
+| config.OTLP_AUTH_USERNAME | string | `""` | Username for OpenTelemetry authentication |
+| config.POSTGRES_STORAGE_ENABLED | string | `"true"` | Enable PostgreSQL storage for blob data |
+| config.SECRET_KEY | string | `"supersecret"` | Secret key used for session management and encryption |
+| config.SWARM_STORAGE_ENABLED | string | `"false"` | Enable Swarm decentralized storage for blob data |
+| config.TRACES_ENABLED | string | `"false"` | Enable distributed tracing |
 | containerSecurityContext | object | See `values.yaml` | The security context for containers |
 | customArgs | list | `["web"]` | Custom args for the blobscan-web container |
 | customCommand | list | `[]` | Command replacement for the blobscan-web container |

--- a/charts/blobscan-web/templates/deployment.yaml
+++ b/charts/blobscan-web/templates/deployment.yaml
@@ -76,6 +76,8 @@ spec:
           env:
             - name: DATABASE_URL
               value: {{ .Values.config.DATABASE_URL | quote }}
+            - name: DIRECT_URL
+              value: {{ .Values.config.DIRECT_URL | quote }}
             - name: NETWORK_NAME
               value: {{ .Values.config.NETWORK_NAME | quote }}
             - name: BLOBSCAN_API_BASE_URL

--- a/charts/blobscan-web/values.yaml
+++ b/charts/blobscan-web/values.yaml
@@ -29,26 +29,41 @@ args: []
 # @default -- See `values.yaml`
 # https://github.com/Blobscan/blobscan/blob/main/.env.example
 config:
+  # -- PostgreSQL connection string for the main database connection
   DATABASE_URL: "postgresql://postgres:postgres@blobscan-blobscandb:5432/blobscan?ssl=false"
+  # -- Direct PostgreSQL connection string, used for Prisma direct database access
+  DIRECT_URL: "postgresql://postgres:postgres@blobscan-blobscandb:5432/blobscan?ssl=false"
+  # -- Ethereum network name (mainnet, holesky, sepolia, gnosis)
   NETWORK_NAME: "mainnet"
+  # -- Base URL for the Blobscan API service
   BLOBSCAN_API_BASE_URL: "http://blobscan-api:3001"
+  # -- Port on which the Blobscan API service listens
   BLOBSCAN_API_PORT: 3001
+  # -- Secret key used for session management and encryption
   SECRET_KEY: "supersecret"
-  # Storages
+  # -- Enable PostgreSQL storage for blob data
   POSTGRES_STORAGE_ENABLED: "true"
+  # -- Enable Swarm decentralized storage for blob data
   SWARM_STORAGE_ENABLED: "false"
+  # -- Enable Google Cloud Storage for blob data
   GOOGLE_STORAGE_ENABLED: "false"
-  # GCS specific
+  # -- Google Cloud Storage bucket name for blob data storage
   GOOGLE_STORAGE_BUCKET_NAME: ""
+  # -- Google Cloud project ID for blob data storage
   GOOGLE_STORAGE_PROJECT_ID: ""
+  # -- Google Cloud service account key for authentication (JSON format)
   GOOGLE_SERVICE_KEY: ""
-  # Opentelemetry
+  # -- Username for OpenTelemetry authentication
   OTLP_AUTH_USERNAME: ""
+  # -- Password for OpenTelemetry authentication
   OTLP_AUTH_PASSWORD: ""
+  # -- Protocol used for OpenTelemetry data export
   OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  # -- Endpoint URL for OpenTelemetry data export
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318"
-
+  # -- Enable metrics collection and reporting
   METRICS_ENABLED: "true"
+  # -- Enable distributed tracing
   TRACES_ENABLED: "false"
 
 # -- Additional env variables

--- a/charts/blobscan/Chart.yaml
+++ b/charts/blobscan/Chart.yaml
@@ -13,13 +13,13 @@ sources:
 dependencies:
 - name: blobscan-web
   repository: "https://blobscan.github.io/blobscan-helm-charts"
-  version: 0.3.2
+  version: 0.3.1
 - name: blobscan-api
   repository: "https://blobscan.github.io/blobscan-helm-charts"
-  version: 0.3.2
+  version: 0.3.1
 - name: blobscan-indexer
   repository: "https://blobscan.github.io/blobscan-helm-charts"
-  version: 0.2.11
+  version: 0.2.10
 - name: postgresql
   repository: "https://charts.bitnami.com/bitnami"
   version: 15.5.20

--- a/charts/blobscan/Chart.yaml
+++ b/charts/blobscan/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: blobscan
-version: 0.4.0
+version: 0.5.0
 description: Blobscan meta-chart (depends on blobscan-api, blobscan-web and blobscan-indexer)
 type: application
 keywords:
@@ -13,13 +13,13 @@ sources:
 dependencies:
 - name: blobscan-web
   repository: "https://blobscan.github.io/blobscan-helm-charts"
-  version: 0.3.1
+  version: 0.3.2
 - name: blobscan-api
   repository: "https://blobscan.github.io/blobscan-helm-charts"
-  version: 0.3.1
+  version: 0.3.2
 - name: blobscan-indexer
   repository: "https://blobscan.github.io/blobscan-helm-charts"
-  version: 0.2.10
+  version: 0.2.11
 - name: postgresql
   repository: "https://charts.bitnami.com/bitnami"
   version: 15.5.20

--- a/charts/blobscan/README.md
+++ b/charts/blobscan/README.md
@@ -15,9 +15,9 @@ Blobscan meta-chart (depends on blobscan-api, blobscan-web and blobscan-indexer)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://blobscan.github.io/blobscan-helm-charts | blobscan-api | 0.3.2 |
-| https://blobscan.github.io/blobscan-helm-charts | blobscan-indexer | 0.2.11 |
-| https://blobscan.github.io/blobscan-helm-charts | blobscan-web | 0.3.2 |
+| https://blobscan.github.io/blobscan-helm-charts | blobscan-api | 0.3.1 |
+| https://blobscan.github.io/blobscan-helm-charts | blobscan-indexer | 0.2.10 |
+| https://blobscan.github.io/blobscan-helm-charts | blobscan-web | 0.3.1 |
 | https://charts.bitnami.com/bitnami | blobscandb(postgresql) | 15.5.20 |
 | https://charts.bitnami.com/bitnami | redis(redis) | 19.6.4 |
 

--- a/charts/blobscan/README.md
+++ b/charts/blobscan/README.md
@@ -40,6 +40,24 @@ Blobscan meta-chart (depends on blobscan-api, blobscan-web and blobscan-indexer)
 | blobscandb.primary.persistence.enabled | bool | `true` |  |
 | blobscandb.primary.persistence.size | string | `"100Gi"` |  |
 | config | object | See `values.yaml` | Config file https://github.com/Blobscan/blobscan/blob/next/.env.example |
+| config.BLOBSCAN_API_BASE_URL | string | `"http://blobscan-api:3001"` | Base URL for the Blobscan API service |
+| config.BLOBSCAN_API_PORT | int | `3001` | Port number for the Blobscan API service |
+| config.DATABASE_URL | string | `"postgresql://postgres:postgres@blobscan-blobscandb:5432/blobscan?ssl=false"` | Database connection URL for PostgreSQL |
+| config.DIRECT_URL | string | `"postgresql://postgres:postgres@blobscan-blobscandb:5432/blobscan?ssl=false"` | Direct database connection URL (no pgbouncer) for PostgreSQL |
+| config.GOOGLE_SERVICE_KEY | string | `""` | Google Cloud service account key for authentication |
+| config.GOOGLE_STORAGE_BUCKET_NAME | string | `""` | Name of the Google Cloud Storage bucket for blob storage |
+| config.GOOGLE_STORAGE_ENABLED | string | `"false"` | Enable Google Cloud Storage for blobs |
+| config.GOOGLE_STORAGE_PROJECT_ID | string | `""` | Google Cloud project ID for GCS |
+| config.METRICS_ENABLED | string | `"true"` | Enable metrics collection |
+| config.NETWORK_NAME | string | `"mainnet"` | Ethereum network name (e.g., mainnet, sepolia, holesky, gnosis) |
+| config.OTEL_EXPORTER_OTLP_ENDPOINT | string | `"http://localhost:4318"` | Endpoint URL for OpenTelemetry exporter |
+| config.OTEL_EXPORTER_OTLP_PROTOCOL | string | `"http/protobuf"` | Protocol for OpenTelemetry exporter |
+| config.OTLP_AUTH_PASSWORD | string | `""` | Password for OpenTelemetry authentication |
+| config.OTLP_AUTH_USERNAME | string | `""` | Username for OpenTelemetry authentication |
+| config.POSTGRES_STORAGE_ENABLED | string | `"true"` | Enable PostgreSQL storage for blobs |
+| config.SECRET_KEY | string | `"supersecret"` | Secret key for session encryption and security |
+| config.SWARM_STORAGE_ENABLED | string | `"false"` | Enable Swarm storage for blobs |
+| config.TRACES_ENABLED | string | `"false"` | Enable distributed tracing |
 | containerSecurityContext | object | See `values.yaml` | The security context for containers |
 | customArgs | list | `["web"]` | Custom args for the blobscan container |
 | customCommand | list | `[]` | Command replacement for the blobscan container |

--- a/charts/blobscan/README.md
+++ b/charts/blobscan/README.md
@@ -1,7 +1,7 @@
 
 # blobscan
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Blobscan meta-chart (depends on blobscan-api, blobscan-web and blobscan-indexer)
 
@@ -15,9 +15,9 @@ Blobscan meta-chart (depends on blobscan-api, blobscan-web and blobscan-indexer)
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://blobscan.github.io/blobscan-helm-charts | blobscan-api | 0.3.1 |
-| https://blobscan.github.io/blobscan-helm-charts | blobscan-indexer | 0.2.10 |
-| https://blobscan.github.io/blobscan-helm-charts | blobscan-web | 0.3.1 |
+| https://blobscan.github.io/blobscan-helm-charts | blobscan-api | 0.3.2 |
+| https://blobscan.github.io/blobscan-helm-charts | blobscan-indexer | 0.2.11 |
+| https://blobscan.github.io/blobscan-helm-charts | blobscan-web | 0.3.2 |
 | https://charts.bitnami.com/bitnami | blobscandb(postgresql) | 15.5.20 |
 | https://charts.bitnami.com/bitnami | redis(redis) | 19.6.4 |
 

--- a/charts/blobscan/values.yaml
+++ b/charts/blobscan/values.yaml
@@ -29,26 +29,42 @@ args: []
 # @default -- See `values.yaml`
 # https://github.com/Blobscan/blobscan/blob/next/.env.example
 config:
+  # -- Database connection URL for PostgreSQL
   DATABASE_URL: "postgresql://postgres:postgres@blobscan-blobscandb:5432/blobscan?ssl=false"
+  # -- Direct database connection URL (no pgbouncer) for PostgreSQL
+  DIRECT_URL: "postgresql://postgres:postgres@blobscan-blobscandb:5432/blobscan?ssl=false"
+  # -- Ethereum network name (e.g., mainnet, sepolia, holesky, gnosis)
   NETWORK_NAME: "mainnet"
+  # -- Base URL for the Blobscan API service
   BLOBSCAN_API_BASE_URL: "http://blobscan-api:3001"
+  # -- Port number for the Blobscan API service
   BLOBSCAN_API_PORT: 3001
+  # -- Secret key for session encryption and security
   SECRET_KEY: "supersecret"
-  # Storages
+  # -- Enable PostgreSQL storage for blobs
   POSTGRES_STORAGE_ENABLED: "true"
+  # -- Enable Swarm storage for blobs
   SWARM_STORAGE_ENABLED: "false"
+  # -- Enable Google Cloud Storage for blobs
   GOOGLE_STORAGE_ENABLED: "false"
-  # GCS specific
+  # -- Name of the Google Cloud Storage bucket for blob storage
   GOOGLE_STORAGE_BUCKET_NAME: ""
+  # -- Google Cloud project ID for GCS
   GOOGLE_STORAGE_PROJECT_ID: ""
+  # -- Google Cloud service account key for authentication
   GOOGLE_SERVICE_KEY: ""
-  # Opentelemetry
+  # -- Username for OpenTelemetry authentication
   OTLP_AUTH_USERNAME: ""
+  # -- Password for OpenTelemetry authentication
   OTLP_AUTH_PASSWORD: ""
+  # -- Protocol for OpenTelemetry exporter
   OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  # -- Endpoint URL for OpenTelemetry exporter
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318"
 
+  # -- Enable metrics collection
   METRICS_ENABLED: "true"
+  # -- Enable distributed tracing
   TRACES_ENABLED: "false"
 
 # -- Additional env variables


### PR DESCRIPTION
Add new required environment variable DIRECT_URL.

By default, if DIRECT_URL isn't defined, it will use the same value as DATABASE_URL. However, if your DATABASE_URL points to a PgBouncer connection, you must explicitly set DIRECT_URL to a direct database connection (without PgBouncer). This is required by Prisma ORM for applying migrations.

Fixes https://github.com/ethpandaops/ethereum-package/issues/916